### PR TITLE
Setting to show category icon from discourse-category-icons component

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -17,6 +17,18 @@ div[class^="category-title-header"] {
     .category-title {
       display: inline;
     }
+
+    .category-icon-widget {
+      display: inline;
+
+      .category-icon {
+        .d-icon {
+          height: 1.5em;
+          width: 1.5em;
+          margin-right: 0.75em;
+        }
+      }
+    }
   }
 
   .category-title-description {

--- a/javascripts/discourse/widgets/category-header-widget.js.es6
+++ b/javascripts/discourse/widgets/category-header-widget.js.es6
@@ -2,11 +2,19 @@ import { h } from "virtual-dom";
 import { iconNode } from "discourse-common/lib/icon-library";
 import { createWidget } from "discourse/widgets/widget";
 
-function buildCategory(category) {
+function buildCategory(category, widget) {
   const content = [];
 
   if (category.read_restricted) {
     content.push(iconNode("lock"));
+  }
+
+  if (settings.show_category_icon) {
+    try {
+      content.push(widget.attach("category-icon", { category }));
+    } catch {
+      // if widget attaching fails, ignore it as it's probably the missing component
+    }
   }
 
   content.push(h("h1.category-title", category.name));
@@ -63,7 +71,7 @@ export default createWidget("category-header-widget", {
               style: `background-color: #${category.color}; color: #${category.text_color};`,
             },
           },
-          h("div.category-title-contents", buildCategory(category))
+          h("div.category-title-contents", buildCategory(category, this))
         );
       }
     } else {

--- a/settings.yml
+++ b/settings.yml
@@ -29,3 +29,7 @@ show_below_site_header:
   default: true
   type: bool
   description: "Display the banner in the below site header connector."
+
+show_category_icon:
+  default: false
+  description: "Show category icon from Discourse Category Icons component"


### PR DESCRIPTION
I've added a setting that enables attaching the widget from discourse-category-icons on the left of the banner title.

This is something I'll use on my community and I thought could be contributed back. I'm no expert on Discourse internals, though, so just let me know if anything can be improved.

Example:
![image](https://user-images.githubusercontent.com/3530/100522595-1525a000-3189-11eb-8519-e23edfd1d958.png)

EDIT: I'm using 1.5em as width/height for the icon, but having tested with 1.75em I think it's slightly better. If you're willing to accept this PR just let me know your preference.