### PR TITLE
REFACTOR: Simplify routing logic and use Category.findBySlugPathWithID

### DIFF
--- a/javascripts/discourse/widgets/category-header-widget.js.es6
+++ b/javascripts/discourse/widgets/category-header-widget.js.es6
@@ -39,20 +39,14 @@ export default createWidget("category-header-widget", {
   html() {
     const router = getOwner(this).lookup("router:main");
     const route = router.currentRoute;
-    let isCategoryTopicList;
-    let params;
-
-    if (route && route.params) {
-      params = route.params;
-      isCategoryTopicList = route.params.hasOwnProperty(
-        "category_slug_path_with_id"
+    if (
+      route &&
+      route.params &&
+      route.params.hasOwnProperty("category_slug_path_with_id")
+    ) {
+      const category = Category.findBySlugPathWithID(
+        route.params.category_slug_path_with_id
       );
-    }
-
-    if (isCategoryTopicList) {
-      const splitPath = params.category_slug_path_with_id.split("/");
-      const categoryId = splitPath[splitPath.length - 1];
-      const category = Category.findById(categoryId);
       const isException = settings.exceptions
         .split("|")
         .filter(Boolean)


### PR DESCRIPTION
This change swaps out `Category.findById` with `Category.findBySlugPathWithID`. It ends up reducing the necessary code and handles the scenario of using a link without a numeric ID (e.g. `/tags/c/some-category/some-tag` instead of  `/tags/c/some-category/4/some-tag`).

This also simplifies the routing logic in line with what was discussed in https://github.com/discourse/discourse-category-banners/pull/8. There's no need to create an `isCategoryTopicList` variable, especially now that the code is a little less busy.