### PR TITLE
DEV: Change lock placement

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -9,13 +9,15 @@ div[class^="category-title-header"] {
     padding: 40px;
 
     .d-icon-lock {
-      height: 1.5em;
-      width: 1.1em;
+      height: 0.75em;
+      width: 0.75em;
       margin-right: 0.25em;
     }
 
     .category-title {
-      display: inline;
+      display: flex;
+      justify-content: center;
+      align-items: center;
     }
 
     .category-icon-widget {

--- a/javascripts/discourse/widgets/category-header-widget.js.es6
+++ b/javascripts/discourse/widgets/category-header-widget.js.es6
@@ -7,10 +7,6 @@ import Category from "discourse/models/category";
 function buildCategory(category, widget) {
   const content = [];
 
-  if (category.read_restricted) {
-    content.push(iconNode("lock"));
-  }
-
   if (settings.show_category_icon) {
     try {
       content.push(widget.attach("category-icon", { category }));
@@ -19,7 +15,11 @@ function buildCategory(category, widget) {
     }
   }
 
-  content.push(h("h1.category-title", category.name));
+  let categoryTitle = category.read_restricted
+    ? [iconNode("lock"), category.name]
+    : category.name;
+
+  content.push(h("h1.category-title", categoryTitle));
 
   if (settings.show_description) {
     content.push(
@@ -88,8 +88,8 @@ export default createWidget("category-header-widget", {
           `div.category-title-header.category-banner-${category.slug}`,
           {
             attributes: {
-              style: `background-color: #${category.color}; color: #${category.text_color};`,
-            },
+              style: `background-color: #${category.color}; color: #${category.text_color};`
+            }
           },
           h("div.category-title-contents", buildCategory(category, this))
         );
@@ -97,5 +97,5 @@ export default createWidget("category-header-widget", {
     } else {
       document.body.classList.remove("category-header");
     }
-  },
+  }
 });


### PR DESCRIPTION
This PR adjusts where the lock is placed in the widget. It will now more closely resemble the way Discourse shows lock icons inside of the title element for category titles. This will allow better customization of displaying the text and icon for users who wish to alter the style of the component.

### After
```html
<h1 class="category-title">
  <svg class="fa d-icon d-icon-lock svg-icon svg-node" aria-hidden="true">
    <use xlink:href="#lock"></use>
  </svg>
  Staff
</h1>

```

### Before
```html
  <svg class="fa d-icon d-icon-lock svg-icon svg-node" aria-hidden="true">
    <use xlink:href="#lock"></use>
  </svg>
  <h1 class="category-title">Staff</h1>
```


## Example of customization:
### After
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/153264831-243859a5-22d2-43f3-9df9-2fb9de597cb4.png">

### Before
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30537603/153275127-439f1a85-9244-4a29-95d6-3936a83daecc.png">

