### PR TITLE
UX: category icon compatibility improvements

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -18,25 +18,7 @@ div[class^="category-title-header"] {
     .d-icon-lock {
       height: 0.75em;
       width: 0.75em;
-      margin-right: 0.25em;
-    }
-
-    .category-title {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    }
-
-    .category-icon-widget {
-      display: flex;
-      .category-icon {
-        display: flex;
-        .d-icon {
-          height: 0.75em;
-          width: 0.75em;
-          margin-right: 0.25em;
-        }
-      }
+      vertical-align: 0;
     }
   }
 
@@ -45,6 +27,26 @@ div[class^="category-title-header"] {
     a:visited {
       color: inherit;
       text-decoration: underline;
+    }
+  }
+}
+
+// styles that impact the category icons theme component
+
+.banner-category-icon-widget-wrapper {
+  display: inline-block;
+
+  .category-icon-widget {
+    display: flex;
+    .category-icon {
+      display: flex;
+      @if $override_category_icon_color == "true" {
+        color: currentColor !important;
+      }
+      .d-icon {
+        height: 0.75em;
+        width: 0.75em;
+      }
     }
   }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -40,7 +40,7 @@ div[class^="category-title-header"] {
       .category-icon {
         display: flex;
         @if $override_category_icon_color == "true" {
-          color: currentColor !important;
+          color: currentColor !important; // overrides inline style
         }
         .d-icon {
           height: 0.75em;

--- a/common/common.scss
+++ b/common/common.scss
@@ -29,23 +29,23 @@ div[class^="category-title-header"] {
       text-decoration: underline;
     }
   }
-}
 
-// styles that impact the category icons theme component
+  // styles that impact the category icons theme component
 
-.banner-category-icon-widget-wrapper {
-  display: inline-block;
+  .category-icon-widget-wrapper {
+    display: inline-block;
 
-  .category-icon-widget {
-    display: flex;
-    .category-icon {
+    .category-icon-widget {
       display: flex;
-      @if $override_category_icon_color == "true" {
-        color: currentColor !important;
-      }
-      .d-icon {
-        height: 0.75em;
-        width: 0.75em;
+      .category-icon {
+        display: flex;
+        @if $override_category_icon_color == "true" {
+          color: currentColor !important;
+        }
+        .d-icon {
+          height: 0.75em;
+          width: 0.75em;
+        }
       }
     }
   }

--- a/javascripts/discourse/components/discourse-category-banners.hbs
+++ b/javascripts/discourse/components/discourse-category-banners.hbs
@@ -13,8 +13,6 @@
           {{#if this.hasIconComponent}}
             {{! For compatibility with https://meta.discourse.org/t/category-icons/104683}}
             <CategoryIcon @category={{this.category}} />
-          {{else}}
-            {{this.consoleWarn}}
           {{/if}}
         {{/if}}
         {{#if this.category.read_restricted}}

--- a/javascripts/discourse/components/discourse-category-banners.hbs
+++ b/javascripts/discourse/components/discourse-category-banners.hbs
@@ -10,8 +10,12 @@
     <div class="category-title-contents">
       <h1 class="category-title">
         {{#if (and (theme-setting "show_category_icon") this.category)}}
-          {{! For compatibility with https://meta.discourse.org/t/category-icons/104683}}
-          <CategoryIcon @category={{this.category}} />
+          {{#if this.hasIconComponent}}
+            {{! For compatibility with https://meta.discourse.org/t/category-icons/104683}}
+            <CategoryIcon @category={{this.category}} />
+          {{else}}
+            {{this.consoleWarn}}
+          {{/if}}
         {{/if}}
         {{#if this.category.read_restricted}}
           {{d-icon "lock"}}

--- a/javascripts/discourse/components/discourse-category-banners.hbs
+++ b/javascripts/discourse/components/discourse-category-banners.hbs
@@ -13,6 +13,8 @@
           {{#if this.hasIconComponent}}
             {{! For compatibility with https://meta.discourse.org/t/category-icons/104683}}
             <CategoryIcon @category={{this.category}} />
+          {{else}}
+            {{this.consoleWarn}}
           {{/if}}
         {{/if}}
         {{#if this.category.read_restricted}}

--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -16,6 +16,13 @@ export default class DiscourseCategoryBanners extends Component {
     return getOwner(this).hasRegistration("component:category-icon");
   }
 
+  get consoleWarn() {
+    // eslint-disable-next-line no-console
+    return console.warn(
+      "The category banners component is trying to use the category icons component, but it is not installed. https://meta.discourse.org/t/category-icons/104683"
+    );
+  }
+
   get isVisible() {
     if (this.categorySlugPathWithID) {
       this.keepDuringLoadingRoute = true;

--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -13,8 +13,7 @@ export default class DiscourseCategoryBanners extends Component {
   @tracked keepDuringLoadingRoute = false;
 
   get hasIconComponent() {
-    const owner = getOwner(this);
-    return owner.hasRegistration("component:category-icon");
+    return getOwner(this).hasRegistration("component:category-icon");
   }
 
   get isVisible() {

--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -4,12 +4,24 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import { getOwner } from "@ember/application";
 
 export default class DiscourseCategoryBanners extends Component {
   @service router;
   @service site;
   @tracked category = null;
   @tracked keepDuringLoadingRoute = false;
+
+  get hasIconComponent() {
+    const owner = getOwner(this);
+    return owner.hasRegistration("component:category-icon");
+  }
+
+  get consoleWarn() {
+    return console.warn(
+      "The category banners component is trying to use the category icons component, but it is not available."
+    );
+  }
 
   get isVisible() {
     if (this.categorySlugPathWithID) {

--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -19,7 +19,7 @@ export default class DiscourseCategoryBanners extends Component {
   get consoleWarn() {
     // eslint-disable-next-line no-console
     return console.warn(
-      "The category banners component is trying to use the category icons component, but it is not installed. https://meta.discourse.org/t/category-icons/104683"
+      "The category banners component is trying to use the category icons component, but it is not available. https://meta.discourse.org/t/category-icons/104683"
     );
   }
 

--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -17,12 +17,6 @@ export default class DiscourseCategoryBanners extends Component {
     return owner.hasRegistration("component:category-icon");
   }
 
-  get consoleWarn() {
-    return console.warn(
-      "The category banners component is trying to use the category icons component, but it is not available."
-    );
-  }
-
   get isVisible() {
     if (this.categorySlugPathWithID) {
       this.keepDuringLoadingRoute = true;

--- a/settings.yml
+++ b/settings.yml
@@ -45,3 +45,7 @@ show_below_site_header:
 show_category_icon:
   default: false
   description: Show category icon from the <a href="https://meta.discourse.org/t/category-icons/104683" target="_blank">Discourse Category Icons component</a>
+
+override_category_icon_color:
+  default: false
+  description: When the category icons are used, enabling this will make the icon match the banner text color


### PR DESCRIPTION
This address some feedback from: https://meta.discourse.org/t/category-banners/86241/164?u=awesomerobot

It improves the alignment of the category icon when available and adds a setting to override its color. 

I've also added a check for the category icons component when the relevant setting is enabled. This avoids the missing category icons component from breaking this component.

This relies on a class name update in the category icons component. https://github.com/discourse/discourse-category-icons/pull/19