### PR TITLE
DEV: ensure class removal when banner doesn't show

### DIFF
--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -45,7 +45,8 @@ export default class DiscourseCategoryBanners extends Component {
     if (this.isVisible && this.keepDuringLoadingRoute) {
       return true;
     } else {
-      return document.body.classList.remove("category-header");
+      document.body.classList.remove("category-header");
+      return false;
     }
   }
 

--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -42,7 +42,11 @@ export default class DiscourseCategoryBanners extends Component {
   }
 
   get shouldRender() {
-    return this.isVisible && this.keepDuringLoadingRoute;
+    if (this.isVisible && this.keepDuringLoadingRoute) {
+      return true;
+    } else {
+      return document.body.classList.remove("category-header");
+    }
   }
 
   get safeStyle() {


### PR DESCRIPTION
The `category-header` class was lingering when it shouldn't have been. This ensures it's always removed when the banner doesn't render. 