### PR TITLE
FIX: account for `no subcategories` list filter

### DIFF
--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -38,7 +38,13 @@ export default class DiscourseCategoryBanners extends Component {
   }
 
   get categorySlugPathWithID() {
-    return this.router?.currentRoute?.params?.category_slug_path_with_id;
+    // when a category is set to Default List Filter: no subcategories
+    // params.category_slug_path_with_id returns undefined
+    // and attributes.category_slug_path_with_id returns the correct value
+    return (
+      this.router?.currentRoute?.params?.category_slug_path_with_id ||
+      this.router?.currentRoute?.attributes?.category_slug_path_with_id
+    );
   }
 
   get shouldRender() {


### PR DESCRIPTION
Issue reported here: https://meta.discourse.org/t/category-banners/86241/174?u=awesomerobot

The router returns a slightly different structure when a category has the `Default List Filter` setting as `no subcategories`... specifically when visiting the category from the `/categories` page. Checking the attributes returns the correct value on these routes. 