### PR TITLE
FEATURE: add features for tag banner integration, clean up

### DIFF
--- a/javascripts/discourse/components/discourse-category-banners.hbs
+++ b/javascripts/discourse/components/discourse-category-banners.hbs
@@ -2,32 +2,34 @@
   <div
     {{did-insert this.getCategory}}
     {{did-update this.getCategory this.isVisible}}
+    {{will-destroy this.teardownComponent}}
     class="category-title-header
       {{if this.category (concat 'category-banner-' this.category.slug)}}"
     style={{if this.category this.safeStyle}}
   >
-
-    <div class="category-title-contents">
-      <h1 class="category-title">
-        {{#if (and (theme-setting "show_category_icon") this.category)}}
-          {{#if this.hasIconComponent}}
-            {{! For compatibility with https://meta.discourse.org/t/category-icons/104683}}
-            <CategoryIcon @category={{this.category}} />
-          {{else}}
-            {{this.consoleWarn}}
+    {{#if this.category}}
+      <div class="category-title-contents">
+        <h1 class="category-title">
+          {{#if (and (theme-setting "show_category_icon") this.category)}}
+            {{#if this.hasIconComponent}}
+              {{! For compatibility with https://meta.discourse.org/t/category-icons/104683}}
+              <CategoryIcon @category={{this.category}} />
+            {{else}}
+              {{this.consoleWarn}}
+            {{/if}}
           {{/if}}
+          {{#if this.category.read_restricted}}
+            {{d-icon "lock"}}
+          {{/if}}
+          {{this.category.name}}
+          <PluginOutlet @name="category-banners-after-title" />
+        </h1>
+        {{#if (theme-setting "show_description")}}
+          <div class="category-title-description">
+            <div class="cooked" innerHTML={{this.category.description}}></div>
+          </div>
         {{/if}}
-        {{#if this.category.read_restricted}}
-          {{d-icon "lock"}}
-        {{/if}}
-        {{this.category.name}}
-      </h1>
-
-      {{#if (theme-setting "show_description")}}
-        <div class="category-title-description">
-          <div class="cooked" innerHTML={{this.category.description}}></div>
-        </div>
-      {{/if}}
-    </div>
+      </div>
+    {{/if}}
   </div>
 {{/if}}

--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -131,7 +131,6 @@ export default class DiscourseCategoryBanners extends Component {
       !hideMobile
     ) {
       document.body.classList.add("category-header");
-      this.categoryBannerPresence.setTo(true);
     } else {
       document.body.classList.remove("category-header");
       this.categoryBannerPresence.setTo(false);

--- a/javascripts/discourse/components/discourse-category-banners.js
+++ b/javascripts/discourse/components/discourse-category-banners.js
@@ -92,7 +92,7 @@ export default class DiscourseCategoryBanners extends Component {
   teardownComponent() {
     document.body.classList.remove("category-header");
     this.category = null;
-    this.categoryBannerPresence.isPresent = false;
+    this.categoryBannerPresence.setTo(false);
   }
 
   @action
@@ -105,7 +105,7 @@ export default class DiscourseCategoryBanners extends Component {
       this.category = Category.findBySlugPathWithID(
         this.categorySlugPathWithID
       );
-      this.categoryBannerPresence.isPresent = true;
+      this.categoryBannerPresence.setTo(true);
       this.keepDuringLoadingRoute = true;
     } else {
       if (!this.router.currentRoute.name.includes("loading")) {
@@ -131,10 +131,10 @@ export default class DiscourseCategoryBanners extends Component {
       !hideMobile
     ) {
       document.body.classList.add("category-header");
-      this.categoryBannerPresence.isPresent = true;
+      this.categoryBannerPresence.setTo(true);
     } else {
       document.body.classList.remove("category-header");
-      this.categoryBannerPresence.isPresent = false;
+      this.categoryBannerPresence.setTo(false);
     }
   }
 }

--- a/javascripts/discourse/services/category-banner-presence.js
+++ b/javascripts/discourse/services/category-banner-presence.js
@@ -1,4 +1,4 @@
-import Service from '@ember/service';
+import Service from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 
 export default class CategoryBannerPresence extends Service {

--- a/javascripts/discourse/services/category-banner-presence.js
+++ b/javascripts/discourse/services/category-banner-presence.js
@@ -3,4 +3,8 @@ import { tracked } from "@glimmer/tracking";
 
 export default class CategoryBannerPresence extends Service {
   @tracked isPresent = false;
+
+  setTo(value) {
+    this.isPresent = value;
+  }
 }

--- a/javascripts/discourse/services/category-banner-presence.js
+++ b/javascripts/discourse/services/category-banner-presence.js
@@ -1,0 +1,6 @@
+import Service from '@ember/service';
+import { tracked } from "@glimmer/tracking";
+
+export default class CategoryBannerPresence extends Service {
+  @tracked isPresent = false;
+}


### PR DESCRIPTION
Pairs with the tag banner component changes here: https://github.com/discourse/discourse-tag-banners/pull/9

This adds a `CategoryBannerPresence` service, which helps with integrating with the tag banner component along with a `category-banners-after-title` plugin outlet.

I've also removed property changes from the getters.

![image](https://user-images.githubusercontent.com/1681963/234099555-e1f0bfc7-30cb-4a40-ab61-676ef9e461a5.png)
