### PR TITLE
UX: add more plugin outlet options

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -50,3 +50,10 @@ div[class^="category-title-header"] {
     }
   }
 }
+
+@if $plugin_outlet == "header-list-container-bottom" {
+  #header-list-area {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+}

--- a/javascripts/discourse/connectors/above-main-container/category-header-banner.hbs
+++ b/javascripts/discourse/connectors/above-main-container/category-header-banner.hbs
@@ -1,0 +1,3 @@
+{{#if (eq (theme-setting "plugin_outlet") "above-main-container")}}
+  <DiscourseCategoryBanners />
+{{/if}}

--- a/javascripts/discourse/connectors/above-site-header/category-header-banner.hbs
+++ b/javascripts/discourse/connectors/above-site-header/category-header-banner.hbs
@@ -1,3 +1,3 @@
-{{#if (theme-setting "show_above_site_header")}}
+{{#if (eq (theme-setting "plugin_outlet") "above-site-header")}}
   <DiscourseCategoryBanners />
 {{/if}}

--- a/javascripts/discourse/connectors/below-site-header/category-header-banner.hbs
+++ b/javascripts/discourse/connectors/below-site-header/category-header-banner.hbs
@@ -1,3 +1,3 @@
-{{#if (theme-setting "show_below_site_header")}}
+{{#if (eq (theme-setting "plugin_outlet") "below-site-header")}}
   <DiscourseCategoryBanners />
 {{/if}}

--- a/javascripts/discourse/connectors/header-list-container-bottom/category-header-banner.hbs
+++ b/javascripts/discourse/connectors/header-list-container-bottom/category-header-banner.hbs
@@ -1,0 +1,3 @@
+{{#if (eq (theme-setting "plugin_outlet") "header-list-container-bottom")}}
+  <DiscourseCategoryBanners />
+{{/if}}

--- a/settings.yml
+++ b/settings.yml
@@ -32,15 +32,15 @@ categories:
      <li> only_sub - only subcategories of the named category.
     </ul>
 
-show_above_site_header:
-  default: false
-  type: bool
-  description: "Display the banner in the above site header connector."
-
-show_below_site_header:
-  default: true
-  type: bool
-  description: "Display the banner in the below site header connector."
+plugin_outlet:
+  default: "below-site-header"
+  type: "enum"
+  choices:
+    - "below-site-header"
+    - "above-site-header"
+    - "above-main-container"
+    - "header-list-container-bottom"
+  description: "Changes the position of the banner on the page."
 
 show_category_icon:
   default: false


### PR DESCRIPTION
This adds some more plugin outlets so the banners can now be optionally shown here:

![Screenshot 2023-07-06 at 4 03 56 PM](https://github.com/discourse/discourse-category-banners/assets/1681963/e1e3d1ff-bb09-4d94-8dd8-249f1056c073)


or here:

![Screenshot 2023-07-06 at 4 03 42 PM](https://github.com/discourse/discourse-category-banners/assets/1681963/1888f642-28cd-49b6-8af0-85ce969f8876)
