### PR TITLE
UX: add category logo option

### DIFF
--- a/javascripts/discourse/components/discourse-category-banners.hbs
+++ b/javascripts/discourse/components/discourse-category-banners.hbs
@@ -9,6 +9,9 @@
   >
     {{#if this.category}}
       <div class="category-title-contents">
+        {{#if (and (theme-setting "show_category_logo") this.category.uploaded_logo.url)}}
+          <CategoryLogo @category={{this.category}} />
+        {{/if}}
         <h1 class="category-title">
           {{#if (and (theme-setting "show_category_icon") this.category)}}
             {{#if this.hasIconComponent}}

--- a/settings.yml
+++ b/settings.yml
@@ -42,6 +42,10 @@ plugin_outlet:
     - "header-list-container-bottom"
   description: "Changes the position of the banner on the page."
 
+show_category_logo:
+  default: false
+  description: Show category logo from a category's settings
+
 show_category_icon:
   default: false
   description: Show category icon from the <a href="https://meta.discourse.org/t/category-icons/104683" target="_blank">Discourse Category Icons component</a>


### PR DESCRIPTION
I use this component quite a lot and often need to show category logos. Opening this pr in case you want to add the feature to the main branch. 

It adds a setting to show the logos, similar to the icons:
![image](https://github.com/discourse/discourse-category-banners/assets/26887899/877dd7cc-d5c2-433a-adc8-8b2427947f7d)

However, the default look right now is:
![image](https://github.com/discourse/discourse-category-banners/assets/26887899/a0a1b676-a0a0-4c38-b635-572a9b032ae3)
Because by default another category header shows when a logo is available. I usually adjust the look with theme styles, but I guess it would need some optional, additional style declarations on the component if merged?