### PR TITLE
DEV: Various improvements to theme

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,6 +1,6 @@
 body:not(.category-header) {
   // hides banners based on outcome of shouldShow
-  .category-header-banner {
+  .category-title-header {
     display: none;
   }
 }

--- a/javascripts/discourse/components/category-banner.hbs
+++ b/javascripts/discourse/components/category-banner.hbs
@@ -24,9 +24,12 @@
           {{this.category.name}}
           <PluginOutlet @name="category-banners-after-title" />
         </h1>
-        {{#if (theme-setting "show_description")}}
+
+        {{#if this.displayCategoryDescription}}
           <div class="category-title-description">
-            <div class="cooked" innerHTML={{this.category.description}}></div>
+            <div class="cooked">
+              {{this.category.description}}
+            </div>
           </div>
         {{/if}}
       </div>

--- a/javascripts/discourse/components/category-banner.js
+++ b/javascripts/discourse/components/category-banner.js
@@ -51,6 +51,10 @@ export default class DiscourseCategoryBanners extends Component {
     );
   }
 
+  get displayCategoryDescription() {
+    return settings.show_description && this.category.description?.length > 0;
+  }
+
   #parseCategories(categoriesStr) {
     const categories = {};
     categoriesStr.split("|").forEach((item) => {
@@ -117,9 +121,9 @@ export default class DiscourseCategoryBanners extends Component {
     const exceptions = this.#parseExceptions(settings.exceptions);
     const isException = exceptions.includes(this.category?.name.toLowerCase());
     const isTarget = this.#checkTargetCategory(categories);
-    const hideMobile = !settings.show_mobile && this.site.mobileView;
-    const isSubCategory =
-      !settings.show_subcategory && this.category?.parentCategory;
+    const hideMobile = this.site.mobileView && !settings.show_mobile;
+    const hideSubCategory =
+      this.category?.parentCategory && !settings.show_subcategory;
     const hasNoCategoryDescription =
       settings.hide_if_no_description && !this.category?.description_text;
 
@@ -127,7 +131,7 @@ export default class DiscourseCategoryBanners extends Component {
       isTarget &&
       !isException &&
       !hasNoCategoryDescription &&
-      !isSubCategory &&
+      !hideSubCategory &&
       !hideMobile
     ) {
       document.body.classList.add("category-header");

--- a/javascripts/discourse/connectors/above-main-container/category-header-banner.hbs
+++ b/javascripts/discourse/connectors/above-main-container/category-header-banner.hbs
@@ -1,3 +1,0 @@
-{{#if (eq (theme-setting "plugin_outlet") "above-main-container")}}
-  <DiscourseCategoryBanners />
-{{/if}}

--- a/javascripts/discourse/connectors/above-site-header/category-header-banner.hbs
+++ b/javascripts/discourse/connectors/above-site-header/category-header-banner.hbs
@@ -1,3 +1,0 @@
-{{#if (eq (theme-setting "plugin_outlet") "above-site-header")}}
-  <DiscourseCategoryBanners />
-{{/if}}

--- a/javascripts/discourse/connectors/below-site-header/category-header-banner.hbs
+++ b/javascripts/discourse/connectors/below-site-header/category-header-banner.hbs
@@ -1,3 +1,0 @@
-{{#if (eq (theme-setting "plugin_outlet") "below-site-header")}}
-  <DiscourseCategoryBanners />
-{{/if}}

--- a/javascripts/discourse/connectors/header-list-container-bottom/category-header-banner.hbs
+++ b/javascripts/discourse/connectors/header-list-container-bottom/category-header-banner.hbs
@@ -1,3 +1,0 @@
-{{#if (eq (theme-setting "plugin_outlet") "header-list-container-bottom")}}
-  <DiscourseCategoryBanners />
-{{/if}}

--- a/javascripts/discourse/initializers/discourse-category-banners.js
+++ b/javascripts/discourse/initializers/discourse-category-banners.js
@@ -1,0 +1,6 @@
+import { apiInitializer } from "discourse/lib/api";
+import CategoryBanner from "../components/category-banner";
+
+export default apiInitializer("1.15.0", (api) => {
+  api.renderInOutlet(settings.plugin_outlet, CategoryBanner);
+});

--- a/settings.yml
+++ b/settings.yml
@@ -41,6 +41,7 @@ plugin_outlet:
     - "above-main-container"
     - "header-list-container-bottom"
   description: "Changes the position of the banner on the page."
+  refresh: true
 
 show_category_icon:
   default: false

--- a/spec/system/category_banners_spec.rb
+++ b/spec/system/category_banners_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "page_objects/components/category_banner"
+
+RSpec.describe "Category Banners", type: :system do
+  fab!(:theme) { upload_theme_component }
+  fab!(:category) { Fabricate(:category, description: "this is some description") }
+  fab!(:category_subcategory) do
+    Fabricate(:category, parent_category: category, description: "some description")
+  end
+  let(:category_banner) { PageObjects::Components::CategoryBanner.new(category) }
+  let(:subcategory_banner) { PageObjects::Components::CategoryBanner.new(category_subcategory) }
+
+  it "displays category banner correctly" do
+    visit("/c/#{category.slug}")
+
+    expect(category_banner).to be_visible
+    expect(category_banner).to have_title(category.name)
+    expect(category_banner).to have_description(category.description)
+  end
+
+  it "does not display the category description when `show_description` setting is false" do
+    theme.update_setting(:show_description, false)
+    theme.save!
+
+    visit("/c/#{category.slug}")
+
+    expect(category_banner).to be_visible
+    expect(category_banner).to have_title(category.name)
+    expect(category_banner).to have_no_description
+  end
+
+  it "should not display category banner on mobile when `show_mobile` settting is false",
+     mobile: true do
+    theme.update_setting(:show_mobile, false)
+    theme.save!
+
+    visit("/c/#{category.slug}")
+
+    expect(category_banner).to be_not_visible
+  end
+
+  it "should not display category banner on subcategories when `show_subcategory` setting is false" do
+    theme.update_setting(:show_subcategory, false)
+    theme.save!
+
+    visit("/c/#{category_subcategory.slug}")
+
+    expect(subcategory_banner).to be_not_visible
+  end
+
+  it "should not display category banner for category when `hide_if_no_description` setting is true and category has no description" do
+    category.update!(description: "")
+    theme.update_setting(:hide_if_no_description, true)
+    theme.save!
+
+    visit("/c/#{category.slug}")
+
+    expect(category_banner).to be_not_visible
+  end
+
+  it "should not display category banners for categories that have been listed in `exceptions` setting" do
+    theme.update_setting(:exceptions, "#{category.name}|#{category_subcategory.name}")
+    theme.save!
+
+    visit("/c/#{category.slug}")
+
+    expect(category_banner).to be_not_visible
+
+    visit("/c/#{category_subcategory.slug}")
+
+    expect(subcategory_banner).to be_not_visible
+  end
+end

--- a/spec/system/page_objects/components/category_banner.rb
+++ b/spec/system/page_objects/components/category_banner.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Components
+    class CategoryBanner < PageObjects::Components::Base
+      def initialize(category)
+        @category = category
+      end
+
+      def visible?
+        has_css?(category_banner_selector)
+      end
+
+      def not_visible?
+        has_no_css?(category_banner_selector)
+      end
+
+      def has_title?(title)
+        has_css?("#{category_banner_selector} .category-title", text: title)
+      end
+
+      def has_description?(description)
+        has_css?(
+          "#{category_banner_selector} .category-title-description .cooked",
+          text: description,
+        )
+      end
+
+      def has_no_description?
+        has_no_css?("#{category_banner_selector} .category-title-description")
+      end
+
+      private
+
+      def category_banner_selector
+        ".category-banner-#{@category.slug}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commits introduces the follow changes:

1. Use the `renderInOutlet` API over the connectors convention
1. Renames `discourse-category-banners` component to `category-banner`
   which is more appropriate cause we are only rendering banner for one
category.
1. Adds system tests