### PR TITLE
FIX: allow HTML in category description

### DIFF
--- a/javascripts/discourse/components/category-banner.hbs
+++ b/javascripts/discourse/components/category-banner.hbs
@@ -28,7 +28,7 @@
         {{#if this.displayCategoryDescription}}
           <div class="category-title-description">
             <div class="cooked">
-              {{this.category.description}}
+              {{html-safe this.category.description}}
             </div>
           </div>
         {{/if}}

--- a/spec/system/category_banners_spec.rb
+++ b/spec/system/category_banners_spec.rb
@@ -4,7 +4,7 @@ require_relative "page_objects/components/category_banner"
 
 RSpec.describe "Category Banners", type: :system do
   let!(:theme) { upload_theme_component }
-  fab!(:category) { Fabricate(:category, description: "this is some description") }
+  fab!(:category) { Fabricate(:category, description: "<p>this is some description</p>") }
   fab!(:category_subcategory) do
     Fabricate(:category, parent_category: category, description: "some description")
   end
@@ -16,7 +16,7 @@ RSpec.describe "Category Banners", type: :system do
 
     expect(category_banner).to be_visible
     expect(category_banner).to have_title(category.name)
-    expect(category_banner).to have_description(category.description)
+    expect(category_banner).to have_description("this is some description")
   end
 
   it "does not display the category description when `show_description` setting is false" do


### PR DESCRIPTION
We allow HTML in category descriptions in core, so I think we should still support this (assuming the removal was unintentional, but let me know if we should take another approach @tgxworld!) 