### PR TITLE
DEV: Move settings descriptions into translation file

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,20 @@
+en:
+  theme_metadata:
+    settings:
+      show_description: 'Show description from "About This Category" post'
+      show_mobile: 'Show banners on mobile'
+      show_subcategory: 'Show banners for subcategories'
+      hide_if_no_description: 'Hide banners if category description is not set'
+      show_category_logo: 'Show category logo'
+      exceptions: "Banner will not show for these category NAMES."
+      categories: |
+        Banner will only show for these categories. Format as <code>name:target</code> (e.g., <code>staff:all</code>).
+        Accepted targets:
+        <ul>
+        <li> all - named category and subcategories (default);
+        <li> no_sub - only the named category;
+        <li> only_sub - only subcategories of the named category.
+        </ul>
+      plugin_outlet: "Changes the position of the banner on the page."
+      show_category_icon: Show category icon from the <a href="https://meta.discourse.org/t/category-icons/104683" target="_blank">Discourse Category Icons component</a>
+      override_category_icon_color: When the category icons are used, enabling this will make the icon match the banner text color

--- a/settings.yml
+++ b/settings.yml
@@ -1,22 +1,17 @@
 show_description:
   default: true
-  description: 'Show description from "About This Category" post'
 
 show_mobile:
   default: true
-  description: "Show banners on mobile"
 
 show_subcategory:
   default: true
-  description: "Show banners for subcategories"
 
 hide_if_no_description:
   default: true
-  description: "Hide banners if category description is not set"
 
 show_category_logo:
   default: false
-  description: "Displays the category logo as set in the category's settings"
 
 align_text:
   default: center
@@ -30,7 +25,6 @@ exceptions:
   default: ""
   type: list
   list_type: simple
-  description: "Banner will not show for these category NAMES."
 
 categories:
   default: ""
@@ -52,13 +46,10 @@ plugin_outlet:
     - "above-site-header"
     - "above-main-container"
     - "header-list-container-bottom"
-  description: "Changes the position of the banner on the page."
   refresh: true
 
 show_category_icon:
   default: false
-  description: Show category icon from the <a href="https://meta.discourse.org/t/category-icons/104683" target="_blank">Discourse Category Icons component</a>
 
 override_category_icon_color:
   default: false
-  description: When the category icons are used, enabling this will make the icon match the banner text color


### PR DESCRIPTION
This commit moves the description for the theme's settings into
`locales/en.yml`. This follows our theme's best practice listed in
https://meta.discourse.org/t/add-localizable-strings-to-themes-and-theme-components/109867
