### PR TITLE
DEV: Add tests for `categories` setting

### DIFF
--- a/spec/system/category_banners_spec.rb
+++ b/spec/system/category_banners_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe "Category Banners", type: :system do
   let!(:theme) { upload_theme_component }
   fab!(:category) { Fabricate(:category, description: "<p>this is some description</p>") }
   fab!(:category_subcategory) do
-    Fabricate(:category, parent_category: category, description: "some description", uploaded_logo: Fabricate(:upload))
+    Fabricate(
+      :category,
+      parent_category: category,
+      description: "some description",
+      uploaded_logo: Fabricate(:upload),
+    )
   end
   let(:category_banner) { PageObjects::Components::CategoryBanner.new(category) }
   let(:subcategory_banner) { PageObjects::Components::CategoryBanner.new(category_subcategory) }
@@ -17,6 +22,47 @@ RSpec.describe "Category Banners", type: :system do
     expect(category_banner).to be_visible
     expect(category_banner).to have_title(category.name)
     expect(category_banner).to have_description("this is some description")
+  end
+
+  context "when `categories` setting has been set" do
+    it "displays category banner for category and its subcategory when target is set to `all`" do
+      theme.update_setting(:categories, "#{category.name}:all")
+      theme.save!
+
+      visit(category.url)
+
+      expect(category_banner).to be_visible
+
+      visit(category_subcategory.url)
+
+      expect(subcategory_banner).to be_visible
+    end
+
+    it "displays category banner only for root category when target is set to `no_sub`" do
+      theme.update_setting(:categories, "#{category.name}:no_sub")
+      theme.save!
+
+      visit(category.url)
+
+      expect(category_banner).to be_visible
+
+      visit(category_subcategory.url)
+
+      expect(subcategory_banner).to be_not_visible
+    end
+
+    it "displays category banner only for sub categories when target is set to `only_sub`" do
+      theme.update_setting(:categories, "#{category.name}:only_sub")
+      theme.save!
+
+      visit(category.url)
+
+      expect(category_banner).to be_not_visible
+
+      visit(category_subcategory.url)
+
+      expect(subcategory_banner).to be_visible
+    end
   end
 
   it "does not display the category description when `show_description` setting is false" do
@@ -73,18 +119,18 @@ RSpec.describe "Category Banners", type: :system do
   it "displays a category logo when show_category_logo is true" do
     theme.update_setting(:show_category_logo, true)
     theme.save!
-  
+
     visit(category_subcategory.url)
-  
+
     expect(subcategory_banner).to have_logo
   end
 
   it "does not display a category logo when show_category_logo is false" do
     theme.update_setting(:show_category_logo, false)
     theme.save!
-  
+
     visit(category_subcategory.url)
-  
+
     expect(subcategory_banner).to have_no_logo
   end
 end


### PR DESCRIPTION
This commit improves the test coverage for the client side logic
surrounding the `categories` theme setting
