### PR TITLE
UX: fix mention color

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -61,6 +61,11 @@ div[class^="category-title-header"] {
       color: currentColor;
       text-decoration: underline;
     }
+
+    a.mention {
+      color: var(--primary);
+      text-decoration: none;
+    }
   }
 
   // styles that impact the category icons theme component


### PR DESCRIPTION
sticking to how mentions look in posts for this one

before:
![image](https://github.com/discourse/discourse-category-banners/assets/1681963/6f20b9ed-62c4-4634-8fc8-459c2f0e2d12)

after:
![image](https://github.com/discourse/discourse-category-banners/assets/1681963/9d47eeef-26f4-4722-9249-35ae2a0718e3)
