### PR TITLE
FIX: Group mention color

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -62,7 +62,7 @@ div[class^="category-title-header"] {
       text-decoration: underline;
     }
 
-    a.mention
+    a.mention,
     a.mention-group {
       color: var(--primary);
       text-decoration: none;

--- a/common/common.scss
+++ b/common/common.scss
@@ -62,7 +62,8 @@ div[class^="category-title-header"] {
       text-decoration: underline;
     }
 
-    a.mention {
+    a.mention
+    a.mention-group {
       color: var(--primary);
       text-decoration: none;
     }


### PR DESCRIPTION
Bug fix that addresses issue reported twice:
https://meta.discourse.org/t/links-in-category-banners-now-show-in-black/307360/7
https://meta.discourse.org/t/category-banners/86241/228

![image](https://github.com/user-attachments/assets/9ea41715-aa0c-4005-88e5-6e92fb9c55b7)
