### PR TITLE
FIX: Group and invalid mention colors

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -62,7 +62,7 @@ div[class^="category-title-header"] {
       text-decoration: underline;
     }
 
-    a.mention
+    a.mention,
     a.mention-group {
       color: var(--primary);
       text-decoration: none;

--- a/common/common.scss
+++ b/common/common.scss
@@ -67,6 +67,10 @@ div[class^="category-title-header"] {
       color: var(--primary);
       text-decoration: none;
     }
+
+    span.mention {
+      color: inherit;
+    }
   }
 
   // styles that impact the category icons theme component

--- a/common/common.scss
+++ b/common/common.scss
@@ -62,7 +62,8 @@ div[class^="category-title-header"] {
       text-decoration: underline;
     }
 
-    a.mention {
+    a.mention
+    a.mention-group {
       color: var(--primary);
       text-decoration: none;
     }


### PR DESCRIPTION
Issue: wrong text color for group mentions and attempted mentions of non-existent users displayed in Category Banner from category descriptions.

Reported on meta:
https://meta.discourse.org/t/links-in-category-banners-now-show-in-black/307360/7
https://meta.discourse.org/t/category-banners/86241/228

![image](https://github.com/user-attachments/assets/f1aecc02-6c8e-48c0-9958-02b0b154f2bb)
