### PR TITLE
FIX: Declare margin on img element

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -18,10 +18,12 @@ body:not(.category-header) {
   .category-logo {
     grid-area: logo;
     align-self: center;
-    margin: 0 1em 0 0;
     --max-height: 8em;
-    @include breakpoint(tablet) {
-      margin: 0 0 0.5em;
+    img {
+      margin: 0 1em 0 0;
+      @include breakpoint(tablet) {
+        margin: 0 0 0.5em;
+      }
     }
   }
   .category-title {


### PR DESCRIPTION
I think it would be better to declare the margin on the nested img element, so the logo cell can fully collapse when no logo img is rendered. 

![image](https://github.com/user-attachments/assets/0e75ace1-740a-4be6-8ac8-8ccb6ffdca60)


However, there's more declarations for category-logo.aspect-image from core, topic-list.scss. Not sure if these should be made more specific in core, or overwritten on the component?