### PR TITLE
FEATURE: use category icons and emojis from core

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -79,23 +79,23 @@ div[class^="category-title-header"] {
     }
   }
 
-  // styles that impact the category icons theme component
-  .category-icon-widget-wrapper {
+  // styles that impact the core category icons
+  .badge-category__wrapper {
     display: inline-block;
+    color: unset;
 
-    .category-icon-widget {
+    .badge-category {
       display: flex;
+      color: currentcolor;
+      justify-content: center;
+      align-items: center;
 
-      .category-icon {
-        display: flex;
+      .d-icon {
+        height: 0.75em;
+        width: 0.75em;
 
         @if $override_category_icon_color == "true" {
-          color: currentcolor !important; // overrides inline style
-        }
-
-        .d-icon {
-          height: 0.75em;
-          width: 0.75em;
+          color: currentcolor;
         }
       }
     }

--- a/common/common.scss
+++ b/common/common.scss
@@ -32,6 +32,10 @@ body:not(.category-header) {
     align-self: end;
   }
 
+  .category-title .badge-category__name {
+    font-size: var(--font-up-1);
+  }
+
   .category-title-description {
     grid-area: description;
   }

--- a/javascripts/discourse/components/category-banner.hbs
+++ b/javascripts/discourse/components/category-banner.hbs
@@ -13,7 +13,14 @@
           <CategoryLogo @category={{this.category}} />
         {{/if}}
         <h1 class="category-title">
-          {{this.categoryName this.category}}
+          {{#if this.showCategoryIcon}}
+            {{this.categoryNameBadge}}
+          {{else}}
+            {{#if this.category.read_restricted}}
+              {{d-icon "lock"}}
+            {{/if}}
+            {{this.category.name}}
+          {{/if}}
 
           <PluginOutlet
             @name="category-banners-after-title"

--- a/javascripts/discourse/components/category-banner.hbs
+++ b/javascripts/discourse/components/category-banner.hbs
@@ -13,18 +13,8 @@
           <CategoryLogo @category={{this.category}} />
         {{/if}}
         <h1 class="category-title">
-          {{#if (and (theme-setting "show_category_icon") this.category)}}
-            {{#if this.hasIconComponent}}
-              {{! For compatibility with https://meta.discourse.org/t/category-icons/104683}}
-              <CategoryIcon @category={{this.category}} />
-            {{else}}
-              {{this.consoleWarn}}
-            {{/if}}
-          {{/if}}
-          {{#if this.category.read_restricted}}
-            {{d-icon "lock"}}
-          {{/if}}
-          {{this.category.name}}
+          {{this.categoryName this.category}}
+
           <PluginOutlet
             @name="category-banners-after-title"
             @outletArgs={{hash category=this.category}}

--- a/javascripts/discourse/components/category-banner.js
+++ b/javascripts/discourse/components/category-banner.js
@@ -3,7 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
-import { categoryBadgeHTML } from "discourse/helpers/category-link";
+import { categoryLinkHTML } from "discourse/helpers/category-link";
 import Category from "discourse/models/category";
 
 export default class DiscourseCategoryBanners extends Component {
@@ -45,20 +45,23 @@ export default class DiscourseCategoryBanners extends Component {
     return settings.show_description && this.category.description?.length > 0;
   }
 
-  categoryName(category) {
-    const hasIcon = category.style_type === "icon" && category.icon;
-    const hasEmoji = category.style_type === "emoji" && category.emoji;
+  get showCategoryIcon() {
+    const hasIcon = this.category.style_type === "icon" && this.category.icon;
+    const hasEmoji =
+      this.category.style_type === "emoji" && this.category.emoji;
 
     if (settings.show_category_icon && (hasIcon || hasEmoji)) {
-      return htmlSafe(
-        categoryBadgeHTML(category, {
-          allowUncategorized: true,
-          link: false,
-        })
-      );
+      return true;
     } else {
-      return category.name;
+      return false;
     }
+  }
+
+  get categoryNameBadge() {
+    return categoryLinkHTML(this.category, {
+      allowUncategorized: true,
+      link: false,
+    });
   }
 
   #parseExceptions(exceptionsStr) {

--- a/javascripts/discourse/components/category-banner.js
+++ b/javascripts/discourse/components/category-banner.js
@@ -1,9 +1,9 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-import { getOwner } from "@ember/application";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 import { htmlSafe } from "@ember/template";
+import { categoryBadgeHTML } from "discourse/helpers/category-link";
 import Category from "discourse/models/category";
 
 export default class DiscourseCategoryBanners extends Component {
@@ -13,10 +13,6 @@ export default class DiscourseCategoryBanners extends Component {
 
   @tracked category = null;
   @tracked keepDuringLoadingRoute = false;
-
-  get hasIconComponent() {
-    return getOwner(this).hasRegistration("component:category-icon");
-  }
 
   get categorySlugPathWithID() {
     return this.router?.currentRoute?.params?.category_slug_path_with_id;
@@ -45,15 +41,24 @@ export default class DiscourseCategoryBanners extends Component {
     );
   }
 
-  get consoleWarn() {
-    // eslint-disable-next-line no-console
-    return console.warn(
-      "The category banners component is trying to use the category icons component, but it is not available. https://meta.discourse.org/t/category-icons/104683"
-    );
-  }
-
   get displayCategoryDescription() {
     return settings.show_description && this.category.description?.length > 0;
+  }
+
+  categoryName(category) {
+    const hasIcon = category.style_type === "icon" && category.icon;
+    const hasEmoji = category.style_type === "emoji" && category.emoji;
+
+    if (settings.show_category_icon && (hasIcon || hasEmoji)) {
+      return htmlSafe(
+        categoryBadgeHTML(category, {
+          allowUncategorized: true,
+          link: false,
+        })
+      );
+    } else {
+      return category.name;
+    }
   }
 
   #parseExceptions(exceptionsStr) {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -21,5 +21,5 @@ en:
                 no_sub - Banner will only show for the selected category
                 only_sub - Banner will only show for the subcategories of the selected category
       plugin_outlet: "Changes the position of the banner on the page"
-      show_category_icon: Show category icon from the <a href="https://meta.discourse.org/t/category-icons/104683" target="_blank">Discourse Category Icons component</a>
+      show_category_icon: Show category icons or emojis added in the Edit Category page
       override_category_icon_color: When the category icons are used, enabling this will make the icon match the banner text color

--- a/spec/system/category_banners_spec.rb
+++ b/spec/system/category_banners_spec.rb
@@ -133,4 +133,41 @@ RSpec.describe "Category Banners", type: :system do
 
     expect(subcategory_banner).to have_no_logo
   end
+
+  describe "with show_category_icon" do
+    before do
+      category.update!(style_type: "icon", icon: "envelope")
+      category_subcategory.update!(style_type: "emoji", emoji: "rocket")
+    end
+
+    context "when true" do
+      before do
+        theme.update_setting(:show_category_icon, true)
+        theme.save!
+      end
+
+      it "displays the icons and emojis" do
+        visit(category.url)
+        expect(category_banner).to have_icon(category.icon)
+
+        visit(category_subcategory.url)
+        expect(subcategory_banner).to have_emoji(category_subcategory.emoji)
+      end
+    end
+
+    context "when false" do
+      before do
+        theme.update_setting(:show_category_icon, false)
+        theme.save!
+      end
+
+      it "does not display the category icon" do
+        visit(category.url)
+        expect(category_banner).to have_no_icon
+
+        visit(category_subcategory.url)
+        expect(subcategory_banner).to have_no_emoji
+      end
+    end
+  end
 end

--- a/spec/system/category_banners_spec.rb
+++ b/spec/system/category_banners_spec.rb
@@ -153,6 +153,17 @@ RSpec.describe "Category Banners", type: :system do
         visit(category_subcategory.url)
         expect(subcategory_banner).to have_emoji(category_subcategory.emoji)
       end
+
+      it "does not display badge when style_type is not icon or emoji" do
+        category.update!(style_type: "square")
+        category_subcategory.update!(style_type: "square")
+
+        visit(category.url)
+        expect(category_banner).to have_no_icon
+
+        visit(category_subcategory.url)
+        expect(subcategory_banner).to have_no_emoji
+      end
     end
 
     context "when false" do

--- a/spec/system/page_objects/components/category_banner.rb
+++ b/spec/system/page_objects/components/category_banner.rb
@@ -38,6 +38,22 @@ module PageObjects
         has_no_css?("#{category_banner_selector} .category-logo img[src]")
       end
 
+      def has_icon?(name)
+        has_css?("#{category_banner_selector} .badge-category.--style-icon .d-icon-#{name}")
+      end
+
+      def has_no_icon?
+        has_no_css?("#{category_banner_selector} .badge-category.--style-icon .d-icon")
+      end
+
+      def has_emoji?(name)
+        has_css?("#{category_banner_selector} .badge-category .emoji[alt='#{name}']")
+      end
+
+      def has_no_emoji?
+        has_no_css?("#{category_banner_selector} .badge-category.--style-emoji .emoji")
+      end
+
       private
 
       def category_banner_selector


### PR DESCRIPTION
Adds support for core changes to category icons and emojis, allowing them to be shown on category banners.

We will soon be deprecating the [Category Icons](https://meta.discourse.org/t/category-icons/104683) theme component since the functionality has been moved into core.

For categories that don't have an icon or emoji (ie. square badge), we just show the category name when the theme has the show icons setting enabled.

### How it looks

Category emojis:

<img width="700" alt="Screenshot 2025-04-29 at 5 22 35 PM" src="https://github.com/user-attachments/assets/ee2b961c-c14b-4fc9-b53c-c93add5ddd4c" />


Category icons:

<img width="700" alt="Screenshot 2025-04-29 at 5 22 55 PM" src="https://github.com/user-attachments/assets/48af52a3-8dda-4084-b9e0-730cd7e2e60a" />


Private category with default square badge (intentionally omitted):

<img width="700" alt="Screenshot 2025-04-29 at 5 06 41 PM" src="https://github.com/user-attachments/assets/5b059691-ccdc-4fdd-b8d7-d4dfbd74df19" />
