### PR TITLE
DEV: replace inline color with a CSS variable

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -47,6 +47,8 @@ div[class^="category-title-header"] {
   display: flex;
   width: 100%;
   justify-content: center;
+  background: var(--category-banner-bg-color);
+  color: var(--category-banner-color);
 
   @if $align_text == "center" {
     text-align: center;

--- a/common/common.scss
+++ b/common/common.scss
@@ -47,7 +47,7 @@ div[class^="category-title-header"] {
   display: flex;
   width: 100%;
   justify-content: center;
-  background: var(--category-banner-bg-color);
+  background: var(--category-banner-background);
   color: var(--category-banner-color);
 
   @if $align_text == "center" {

--- a/javascripts/discourse/components/category-banner.gjs
+++ b/javascripts/discourse/components/category-banner.gjs
@@ -45,7 +45,7 @@ export default class DiscourseCategoryBanners extends Component {
 
   get safeStyle() {
     return htmlSafe(
-      `background-color: #${this.category.color}; color: #${this.category.text_color};`
+      `--category-banner-bg-color: #${this.category.color}; --category-banner-color: #${this.category.text_color};`
     );
   }
 

--- a/javascripts/discourse/components/category-banner.gjs
+++ b/javascripts/discourse/components/category-banner.gjs
@@ -45,7 +45,7 @@ export default class DiscourseCategoryBanners extends Component {
 
   get safeStyle() {
     return htmlSafe(
-      `--category-banner-bg-color: #${this.category.color}; --category-banner-color: #${this.category.text_color};`
+      `--category-banner-background: #${this.category.color}; --category-banner-color: #${this.category.text_color};`
     );
   }
 


### PR DESCRIPTION
Requested here: https://meta.discourse.org/t/could-inline-styles-be-generally-set-with-css-variables/368612

This replaces the inline colors with variables that are assigned the colors. The variables are then applied to the `div[class^="category-title-header"]`. This shouldn't result in any changes other than how the colors are set, overrides in themes will still apply. 